### PR TITLE
reworks how `install_prerequisites.py` handles Python packages

### DIFF
--- a/.github/workflows/install_prerequisites.yaml
+++ b/.github/workflows/install_prerequisites.yaml
@@ -45,11 +45,13 @@ jobs:
           sudo docker run --network=host -t -v $PWD:$HOME -w $HOME --rm ubuntu bash -c
             'apt-get update &&
              apt-get upgrade -y &&
-             echo 11 33 | apt-get install tzdata &&
+             echo 11 33 | apt-get install -y tzdata &&
+             ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime &&
+             dpkg-reconfigure -fnoninteractive tzdata &&
              apt-get install -y software-properties-common &&
-             apt-get install -y gcc g++ wget lsb-release &&
+             apt-get install -y gcc g++ wget lsb-release python3-venv &&
              yes | ./install_prerequisites.py &&
-             ./new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git /tmp/test &&
+             ${HOME}/.config/new_cxx_project/bin/python new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git /tmp/test &&
              cmake -GNinja -S/tmp/test -B/tmp/build -DCMAKE_BUILD_TYPE=Debug &&
              ninja -C /tmp/build'
       - name: Test pacman
@@ -59,7 +61,7 @@ jobs:
           sudo docker run --network=host -t -v $PWD:$HOME -w $HOME --rm archlinux bash -c
             'yes | pacman -Syu python3 &&
              yes | ./install_prerequisites.py &&
-             ./new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git /tmp/test &&
+             ${HOME}/.config/new_cxx_project/bin/python new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git /tmp/test &&
              cmake -GNinja -S/tmp/test -B/tmp/build -DCMAKE_BUILD_TYPE=Debug &&
              ninja -C /tmp/build'
       - name: Test dnf
@@ -69,7 +71,7 @@ jobs:
           sudo docker run --network=host -t -v $PWD:$HOME -w $HOME --rm fedora bash -c
             'yes | dnf update &&
              yes | ./install_prerequisites.py &&
-             ./new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git /tmp/test &&
+             ${HOME}/.config/new_cxx_project/bin/python new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git /tmp/test &&
              cmake -GNinja -S/tmp/test -B/tmp/build -DCMAKE_BUILD_TYPE=Debug &&
              ninja -C /tmp/build'
       - name: Test Homebrew
@@ -77,7 +79,6 @@ jobs:
         if: matrix.os == 'macos-14'
         run: |
           ./install_prerequisites.py
-          export PATH="$HOME/.new_cxx_project/bin:$PATH"
-          ./new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git $HOME/test
+          $HOME/.config/new_cxx_project/bin/python new_cxx_project.py --author new_cxx_project --package-manager=vcpkg --remote=https://github.com/new_cxx_project/test.git $HOME/test
           cmake -GNinja -S $HOME/test -B $HOME/test/build -DCMAKE_BUILD_TYPE=Debug
           ninja -C $HOME/test/build

--- a/.github/workflows/test_new_cxx_project.yml
+++ b/.github/workflows/test_new_cxx_project.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository universe
           sudo apt-get update
-          sudo apt-get install -y gcc-14 g++-14 wget lsb-release
+          sudo apt-get install -y gcc-14 g++-14 wget lsb-release python3-venv
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-get remove -y '*clang*' '*llvm*'
           sudo apt-get autoremove -y
@@ -76,6 +76,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
           sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 100
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 100
+          echo "${HOME}/.config/new_cxx_project/bin" >> ${GITHUB_PATH}
 
       - name: Configure
         id: configure

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ files that ship with the project by default.
 1. This project is fairly straightforward to use. Most projects can probably get away with running the
 following:
   ```sh
-  $ ./new_cxx_project.py /tmp/hello_world --author='Your name'
+  $ ${HOME}/.config/new_cxx_project/python new_cxx_project.py /tmp/hello_world --author='Your name'
   ```
   This generates a project called `hello_world` in `/tmp/hello_world`.
 2. Create a file called `/tmp/hello_world/source/hello.cpp`:
@@ -107,12 +107,14 @@ following:
   ```sh
   # If you have the LLVM toolchain installed (Clang, libc++, and friends)
   $ cmake -GNinja -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$PWD/config/cmake/toolchains/x86_64-linux-unknown-llvm.cmake"
+  ```
+  ```sh
   # If you have the GNU toolchain installed (GCC and friends)
   $ cmake -GNinja -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE="$PWD/config/cmake/toolchains/x86_64-linux-unknown-gnu.cmake"
   ```
-. Now run `ninja -C build`.
-6. Finally, run `build/source/hello`. You should see `Hello, world!` output to screen.
-7. Congrats! That's your first project done :)
+6. Now run `ninja -C build`.
+7. Finally, run `build/source/hello`. You should see `Hello, world!` output to screen.
+8. Congrats! That's your first project done :)
 
 ## Options
 

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,3 +1,4 @@
+GitPython
 sphinx
 myst-parser
 psutil

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,6 +23,10 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+gitdb==4.0.11
+    # via gitpython
+gitpython==3.1.43
+    # via -r requirements.in
 idna==3.7
     # via requests
 imagesize==1.4.1
@@ -60,6 +64,8 @@ pyyaml==6.0.1
     # via myst-parser
 requests==2.32.3
     # via sphinx
+smmap==5.0.1
+    # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5


### PR DESCRIPTION
The script now installs all Python packages to
`${HOME}/.config/new_cxx_project` instead of as system packages, which minimises the impact this script has on the user environment.

This is more in line with the request made in #11.

## Tests

Tested by CI.

## Benchmarks

N/A

## Other checks

- [x] Adds or updates relevant unit tests
- [x] Relevant fuzz tests were added
- [x] Documentation has been updated
